### PR TITLE
Disabling broken Deface::Override call to missing store_credits/limit partial

### DIFF
--- a/app/overrides/views_decorator.rb
+++ b/app/overrides/views_decorator.rb
@@ -26,8 +26,9 @@ Deface::Override.new(
   :partial => "spree/users/store_credits",
   :disabled => false)
 
-Deface::Override.new(:virtual_path => "spree/admin/general_settings/edit",
-                     :name => "admin_general_settings_edit_for_sc",
-                     :insert_before => "[data-hook='buttons']",
-                     :partial => "spree/admin/store_credits/limit",
-                     :disabled => false)
+Deface::Override.new(
+  :virtual_path => "spree/admin/general_settings/edit",
+  :name => "admin_general_settings_edit_for_sc",
+  :insert_before => "[data-hook='buttons']",
+  :partial => "spree/admin/store_credits/limit",
+  :disabled => true)


### PR DESCRIPTION
Reformatting Deface::Override call to admin/store_credits/limit partial to match other calls. Disabling same call since the limit partial is not included in the source tree and causes a fatal error.
