### PR TITLE
actually need this as a string on spree 1.1

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -55,7 +55,7 @@ module Spree
 
     # consume users store credit once the order has completed.
     fsm = self.state_machines[:state]
-    fsm.after_transition :to => :complete, :do => :consume_users_credit
+    fsm.after_transition :to => 'complete', :do => :consume_users_credit
 
     def consume_users_credit
       return unless completed?


### PR DESCRIPTION
They're declared as strings here:
https://github.com/spree/spree/blob/1-1-stable/core/app/models/spree/ord
er.rb
