### PR TITLE
Spree 1-3-stable compatable process_payments! and payment method

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -16,7 +16,7 @@ Spree::Order.class_eval do
   spree_process_payments = instance_method(:process_payments!)
 
   define_method(:process_payments!) do
-    if total > 0 && payment.nil?
+    if total > 0 && pending_payments.nil?
       false
     else
       #execute the process_payments! method from the original Spree Order model.
@@ -65,7 +65,7 @@ Spree::Order.class_eval do
 
     # recalc totals and ensure payment is set to new amount
     update_totals
-    payment.amount = total if payment
+    pending_payments.first.amount = total if pending_payments.first
   end
 
   def consume_users_credit
@@ -100,8 +100,4 @@ Spree::Order.class_eval do
     end
   end
 
-  #add payment method for spree 1.3.3-beta compatibility
-  def payment
-    payments.first
-  end
 end


### PR DESCRIPTION
Corrects process_payments! ignoring order total when processing entered credit cards. This was causing multiple charges to go through on occasion.

Also replaces references to the Spree::Order payment method since that method was removed from the Spree::Order model in commit:
https://github.com/spree/spree/blob/3d0fa4ff434569ff8491aba690fde87e577ec19c/core/app/models/spree/order.rb

This was causing a method undefined error when spree_store_credits was invoked.
