### PR TITLE
Fix gemspec spree dependencies

### DIFF
--- a/lib/spree_store_credits.rb
+++ b/lib/spree_store_credits.rb
@@ -1,4 +1,5 @@
-require 'spree'
+require 'spree_core'
+require 'spree_promo'
 
 module SpreeStoreCredits
   class Engine < Rails::Engine

--- a/spree_store_credits.gemspec
+++ b/spree_store_credits.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'spree', '~> 1.0'
+  s.add_dependency 'spree_core', '~> 1.1'
+  s.add_dependency 'spree_promo', '~> 1.1'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'ffaker'


### PR DESCRIPTION
don't require all of 'spree' in gemspec.  Made it impossible to exclude spree_dash
