### PR TITLE
Use Spree::Price to parse the credit value.

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -7,7 +7,9 @@ module Spree
       load_order
 
       return unless params[:order] && params[:order][:store_credit_amount]
-      store_credit_amount = [BigDecimal.new(params[:order][:store_credit_amount]), spree_current_user.store_credits_total].min
+      parsed_credit = Spree::Price.new
+      parsed_credit.price = params[:order][:store_credit_amount]
+      store_credit_amount = [parsed_credit.price, spree_current_user.store_credits_total].min
       if store_credit_amount >= (current_order.total + @order.store_credit_amount)
         params[:order].delete(:source_attributes)
         params.delete(:payment_source)


### PR DESCRIPTION
The notation of money values differs depending on the locale. In German language decimal delimiter and separator are exchanged compared to the English notation.

12,300.34$ or
12.300,34€

 To parse the language dependent store credit value, the built-in Spree::Price model is used instead of plain BigDecimal.
