### PR TITLE
Change preference type from float to decimal

### DIFF
--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,3 +1,3 @@
 Spree::AppConfiguration.class_eval do
-  preference :use_store_credit_minimum, :float, :default => 0.0
+  preference :use_store_credit_minimum, :decimal, :default => 0.0
 end


### PR DESCRIPTION
Float is not a valid preference type, so when retrieving this preference it returns it as a string, causing type errors. This change fixes this and causes the value to be returned as a BigDecimal.
