### PR TITLE
backports change made to how files are loaded so that files aren't 

### DIFF
--- a/lib/spree_store_credits.rb
+++ b/lib/spree_store_credits.rb
@@ -11,7 +11,7 @@ module SpreeStoreCredits
 
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|        
+      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|        
         (Rails.configuration.cache_classes || Rails.env.development?) ? require(c) : load(c)
       end
     end

--- a/lib/spree_store_credits.rb
+++ b/lib/spree_store_credits.rb
@@ -9,9 +9,10 @@ module SpreeStoreCredits
       g.test_framework :rspec
     end
 
+
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
-        Rails.env == "production" ? require(c) : load(c)
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end
 

--- a/lib/spree_store_credits.rb
+++ b/lib/spree_store_credits.rb
@@ -11,8 +11,8 @@ module SpreeStoreCredits
 
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|        
+        (Rails.configuration.cache_classes || Rails.env.development?) ? require(c) : load(c)
       end
     end
 


### PR DESCRIPTION
loaded twice in non-production environments that cache their classes (staging, qa)

see https://github.com/spree-contrib/spree_store_credits/issues/66 for details
